### PR TITLE
refactor(constants): 优化事件名称

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -18,49 +18,59 @@ export const STATUS_GROUP_SELECTED = 'group-selected';
 export const STATUS_MULTI_SELECTED = 'multi-selected';
 
 /* eslint-disable */
-export const GRAPH_MOUSE_EVENTS = [
-  'click',                // 鼠标左键点击事件
-  'dblclick',             // 鼠标左键双击事件
-  'mouseenter',           // 鼠标移入事件
-  'mouseleave',           // 鼠标移除事件
-  'mousedown',            // 鼠标按下事件
-  'mouseup',              // 鼠标抬起事件
-  'mousemove',            // 鼠标移动事件
-  'dragstart',            // 鼠标开始拖拽事件
-  'drag',                 // 鼠标拖拽事件
-  'dragend',              // 鼠标拖拽结束事件
-  'dragenter',            // 鼠标拖拽进入事件
-  'dragleave',            // 鼠标拖拽移出事件
-  'drop',                 // 鼠标拖拽放置事件
-  'contextmenu',          // 菜单事件
-];
+export const GRAPH_MOUSE_REACT_EVENTS = {
+  click: 'Click',
+  contextmenu: 'ContextMenu',
+  dblclick: 'DoubleClick',
+  drag: 'Drag',
+  Itemdragend: 'DragEnd',
+  dragenter: 'DragEnter',
+  dragleave: 'DragLeave',
+  dragstart: 'DragStart',
+  drop: 'Drop',
+  mousedown: 'MouseDown',
+  mouseenter: 'MouseEnter',
+  mouseleave: 'MouseLeave',
+  mousemove: 'MouseMove',
+  mouseup: 'MouseUp',
+};
 
-export const GRAPH_OTHER_EVENTS = [
-  'mousewheel',           // 鼠标滚轮事件
-  'keydown',              // 键盘按键按下事件
-  'keyup',                // 键盘按键抬起事件
-  'beforechange',         // 子项数据变化前
-  'afterchange',          // 子项数据变化后
-  'beforechangesize',     // 画布尺寸变化前
-  'afterchangesize',      // 画布尺寸变化后
-  'beforeviewportchange', // 视口变化前
-  'afterviewportchange',  // 视口变化后
-];
+export const GRAPH_OTHER_REACT_EVENTS = {
+  afterChange: 'onAfterChange',
+  afterChangeSize: 'onAfterChangeSize',
+  afterViewportChange: 'onAfterViewportChange',
+  beforeChange: 'onBeforeChange',
+  beforeChangeSize: 'onBeforeChangeSize',
+  beforeViewportChange: 'onBeforeViewportChange',
+  keydown: 'onKeyDown',
+  keyup: 'onKeyUp',
+  mousewheel: 'onMouseWheel',
+};
 
-export const PAGE_EVENTS = [
-  'beforeitemactived',    // 激活前
-  'afteritemactived',     // 激活后
-  'beforeitemunactived',  // 取消激活前
-  'afteritemunactived',   // 取消激活后
-  'beforeitemselected',   // 选中前
-  'afteritemselected',    // 选中后
-  'beforeitemunselected', // 取消选中前
-  'afteritemunselected',  // 取消选中后
-  'keyupeditlabel',       // 键盘按键抬起事件（节点编辑）
-];
+export const PAGE_REACT_EVENTS = {
+  afteritemactived: 'onAfterItemActived',
+  afteritemselected: 'onAfterItemSelected',
+  afteritemunactived: 'onAfterItemUnactived',
+  afteritemunselected: 'onAfterItemUnselected',
+  beforeitemactived: 'onBeforeItemActived',
+  beforeitemselected: 'onBeforeItemSelected',
+  beforeitemunactived: 'onBeforeItemUnactived',
+  beforeitemunselected: 'onBeforeItemUnselected',
+  keyupeditlabel: 'onKeyUpEditLabel',
+};
 
-export const EDITOR_EVENTS = [
-  'beforecommandexecute', // 命令执行前
-  'aftercommandexecute',  // 命令执行后
-];
+export const EDITOR_REACT_EVENTS = {
+  aftercommandexecute: 'onAfterCommandExecute',
+  beforecommandexecute: 'onBeforeCommandExecute',
+};
+
+
+export const GRAPH_MOUSE_EVENTS = Object.keys(GRAPH_MOUSE_REACT_EVENTS);
+
+export const GRAPH_OTHER_EVENTS = Object.keys(GRAPH_OTHER_REACT_EVENTS);
+
+export const PAGE_EVENTS = Object.keys(PAGE_REACT_EVENTS);
+
+export const EDITOR_EVENTS = Object.keys(EDITOR_REACT_EVENTS);
+
 /* eslint-enable */

--- a/src/components/GGEditor/index.js
+++ b/src/components/GGEditor/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Editor from '@antv/g6-editor';
-import { EDITOR_EVENTS } from '@common/constants';
-import { pick, upperFirst, createId } from '@utils';
+import { EDITOR_EVENTS, EDITOR_REACT_EVENTS } from '@common/constants';
+import { pick, createId } from '@utils';
 import PropsAPI from '@components/Adapter/propsAPI';
 
 class GGEditor extends React.Component {
@@ -42,7 +42,7 @@ class GGEditor extends React.Component {
 
   bindEvent() {
     EDITOR_EVENTS.forEach((event) => {
-      this.addListener(this.editor, [event], this.props[`on${upperFirst(event)}`]);
+      this.addListener(this.editor, [event], this.props[EDITOR_REACT_EVENTS[event]]);
     });
   }
 

--- a/src/components/Page/index.js
+++ b/src/components/Page/index.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { pick, merge, upperFirst } from '@utils';
-import { GRAPH_MOUSE_EVENTS, GRAPH_OTHER_EVENTS, PAGE_EVENTS } from '@common/constants';
+import { pick, merge } from '@utils';
+import {
+  GRAPH_MOUSE_EVENTS,
+  GRAPH_OTHER_EVENTS,
+  PAGE_EVENTS,
+  GRAPH_MOUSE_REACT_EVENTS,
+  GRAPH_OTHER_REACT_EVENTS,
+  PAGE_REACT_EVENTS,
+} from '@common/constants';
 import BaseComponent from '@components/Base';
 
 class Page extends BaseComponent {
@@ -76,16 +83,17 @@ class Page extends BaseComponent {
     const { addListener } = this;
 
     GRAPH_MOUSE_EVENTS.forEach((event) => {
-      addListener(this.graph, `node:${event}`, this.props[`onNode${upperFirst(event)}`]);
-      addListener(this.graph, `edge:${event}`, this.props[`onEdge${upperFirst(event)}`]);
+      const eventName = GRAPH_MOUSE_REACT_EVENTS[event];
+      addListener(this.graph, `node:${event}`, this.props[`onNode${eventName}`]);
+      addListener(this.graph, `edge:${event}`, this.props[`onEdge${eventName}`]);
     });
 
     GRAPH_OTHER_EVENTS.forEach((event) => {
-      addListener(this.graph, [event], this.props[`on${upperFirst(event)}`]);
+      addListener(this.graph, [event], this.props[GRAPH_OTHER_REACT_EVENTS[event]]);
     });
 
     PAGE_EVENTS.forEach((event) => {
-      addListener(this.page, [event], this.props[`on${upperFirst(event)}`]);
+      addListener(this.page, [event], this.props[PAGE_REACT_EVENTS[event]]);
     });
   }
 


### PR DESCRIPTION
Many of the event names in the G6 editor are not in camelcase or snack case. That is really hard to work with and translate to react style events, like from `afteritemunselected` to `onAfterItemUnselected`.

This PR is to list out all graph events with its according react events in the `constants.js` as a hash object.

Related issue: https://github.com/gaoli/gg-editor/issues/10