### PR TITLE
fix: Rename the event `onBeforeItemUnactived` to `onBeforeItemInactivated`

### DIFF
--- a/docs/api/pageEvents.en-US.md
+++ b/docs/api/pageEvents.en-US.md
@@ -82,8 +82,8 @@ import GGEditor, { Flow } from 'gg-editor';
 | onAfterViewportChange | This event is fired after the `onViewportChange` event. |
 | onBeforeItemActived | This event is fired before the item is activated. |
 | onAfterItemActived | This event is fired after the item is activated. |
-| onBeforeItemUnactived | This event is fired before the item is inactivated. |
-| onAfterItemUnactived | This event is fired after the item is inactivated. |
+| onBeforeItemInactivated | This event is fired before the item is inactivated. |
+| onAfterItemInactivated | This event is fired after the item is inactivated. |
 | onBeforeItemSelected | This event is fired before the item is selected. |
 | onAfterItemSelected | This event is fired after the item is selected. |
 | onBeforeItemUnselected | This event is fired before the item is unselected.

--- a/docs/api/pageEvents.zh-CN.md
+++ b/docs/api/pageEvents.zh-CN.md
@@ -82,8 +82,8 @@ import GGEditor, { Flow } from 'gg-editor';
 | onAfterViewportChange | 视口变化后 |
 | onBeforeItemActived | 激活前 |
 | onAfterItemActived | 激活后 |
-| onBeforeItemUnactived | 取消激活前 |
-| onAfterItemUnactived | 取消激活后 |
+| onBeforeItemInactivated | 取消激活前 |
+| onAfterItemInactivated | 取消激活后 |
 | onBeforeItemSelected | 选中前 |
 | onAfterItemSelected | 选中后 |
 | onBeforeItemUnselected | 取消选中前 |

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -49,12 +49,14 @@ export const GRAPH_OTHER_REACT_EVENTS = {
 
 export const PAGE_REACT_EVENTS = {
   afteritemactived: 'onAfterItemActived',
+  afteriteminactivated: 'onAfterItemInactivated',
   afteritemselected: 'onAfterItemSelected',
-  afteritemunactived: 'onAfterItemUnactived',
+  afteritemunactived: 'onAfterItemInactivated',
   afteritemunselected: 'onAfterItemUnselected',
   beforeitemactived: 'onBeforeItemActived',
+  beforeiteminactivated: 'onBeforeItemInactivated',
   beforeitemselected: 'onBeforeItemSelected',
-  beforeitemunactived: 'onBeforeItemUnactived',
+  beforeitemunactived: 'onBeforeItemInactivated',
   beforeitemunselected: 'onBeforeItemUnselected',
   keyupeditlabel: 'onKeyUpEditLabel',
 };


### PR DESCRIPTION
Rename the event `onBeforeItemUnactived` to `onBeforeItemInactivated` as "unactived" is not really a word. Make it compatible with future changes.