### PR TITLE
docs: Fix the broken link on markdown

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/gg-editor.svg)](https://www.npmjs.com/package/gg-editor)
 [![npm downloads](https://img.shields.io/npm/dm/gg-editor.svg)](https://www.npmjs.com/package/gg-editor)
 
-基于 G6 和 React 的可视化图编辑器
+基于 [G6](https://github.com/antvis/g6) 和 [React](https://github.com/facebook/react) 的可视化图编辑器
 
 ![Flow](https://camo.githubusercontent.com/20982b9b9043c92c8bbe337ae4d47d684d63d2c1/68747470733a2f2f67772e616c697061796f626a656374732e636f6d2f7a6f732f726d73706f7274616c2f6e7a6d79634265776a66784b4462657054446c542e676966)
 
@@ -16,13 +16,13 @@
 
 ### npm
 
-```
-npm i gg-editor
+```sh
+npm install --save gg-editor
 ```
 
 ### umd
 
-```
+```html
 <script src="https://unpkg.com/gg-editor@${version}/dist/bundle.js"></script>
 ```
 

--- a/docs/api/flow.en-US.md
+++ b/docs/api/flow.en-US.md
@@ -20,7 +20,7 @@ import GGEditor, { Flow } from 'gg-editor';
 | graph | To configurate the graph. See more on [G6 Graph API (Chinese)](https://antv.alipay.com/zh-cn/g6/1.x/api/graph.html). | `object` | - |
 | align | To set the alignment. | [`object`](#Align) | - |
 | grid | To set the grid. | [`object`](#Grid) | - |
-| shortcut | To set the shortcut keys. See more on [Built-in Commands](./command.en-US.md# Built-in Commands). | [`object`](#Shortcut) | - |
+| shortcut | To set the shortcut keys. See more on [Built-in Commands](./command.en-US.md#Built-in%20Commands). | [`object`](#Shortcut) | - |
 | noEndEdge | To set if the no-end-edge is supported. | `boolean` | `true` |
 
 ### Align

--- a/docs/api/itemPanel.en-US.md
+++ b/docs/api/itemPanel.en-US.md
@@ -34,6 +34,6 @@ import GGEditor, { Flow, Item, ItemPanel } from 'gg-editor';
 | :--- | :--- | :--- | :--- |
 | type | **required** The type of an item. Options: `node`, `edge`. | `string` | - |
 | size | **required** The size of an item. Format: `50*50`. | `string` | - |
-| shape | **required** The shape of an item. Built-in shapes: [node](./registerNode.en-US.md#Built-in Nodes), [edge](./registerEdge.en-US.md#Built-in Edges). | `string` | - |
+| shape | **required** The shape of an item. Built-in shapes: [node](./registerNode.en-US.md#Built-in%20Nodes), [edge](./registerEdge.en-US.md#Built-in%20Edges). | `string` | - |
 | model | The initial model of an item. | `object` | - |
 | src | The overview image source of an item. | `string` | - |

--- a/docs/api/mind.en-US.md
+++ b/docs/api/mind.en-US.md
@@ -18,7 +18,7 @@ import GGEditor, { Mind } from 'gg-editor';
 | :--- | :--- | :--- | :--- |
 | data | The initial data. | `object` | - |
 | graph | To configurate the graph. See more on [G6 Graph API (Chinese)](https://antv.alipay.com/zh-cn/g6/1.x/api/graph.html). | `object` | - |
-| shortcut | To set the shortcut key [Built-in Commands](./command.en-US.md#Built-in Commands). | [`object`](#Shortcut) | - |
+| shortcut | To set the shortcut key [Built-in Commands](./command.en-US.md#Built-in%20Commands). | [`object`](#Shortcut) | - |
 
 
 ### Shortcut

--- a/docs/api/registerCommand.en-US.md
+++ b/docs/api/registerCommand.en-US.md
@@ -19,4 +19,4 @@ import GGEditor, { Flow, RegisterCommand } from 'gg-editor';
 | :--- | :--- | :--- | :--- |
 | name | The name of a command. | `string` | - |
 | config | To configurate a command. | `object` | - |
-| extend | To extend a command. See more on [Built-in Commands](./command.en-US.md#Built-in Commands). | `string` | - |
+| extend | To extend a command. See more on [Built-in Commands](./command.en-US.md#Built-in%20Commands). | `string` | - |


### PR DESCRIPTION
- Fix the broken link on markdown in docs.
- Modify the docs on `zh-CN` version to sync up with the `en-US` version.