### PR TITLE
fix: Typescript interface typos

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -210,7 +210,7 @@ declare module 'gg-editor' {
   }
 
   export interface PropsApi {
-    propsApi: {
+    propsAPI: {
       executeCommand?(command: EditorCommand)
       read?(data: any)
       save?(): any

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -119,9 +119,9 @@ declare module 'gg-editor' {
     domX?: number
     domY?: number
     /** DOM 原生事件 */
-    domeEvent?: any
+    domEvent?: any
     /** drag 拖动图项 */
-    currentIem?: any
+    currentItem?: any
     /** drag 拖动图形 */
     currentShape?: any
     /** mouseleave dragleave 到达的图形 */


### PR DESCRIPTION
`domeEvent` should be `domEvent`.
`currentIem` should be `currentItem`.
`propsApi` should be `propsAPI`.